### PR TITLE
fix: add fix for common path function when formatting files at direct…

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,7 @@ export function getCommonPath(paths: string[]): string {
   const splitPaths = paths.map((singlePath) => singlePath.split(sep))
   let commonPath = ""
 
-  for (let i = 0; i < splitPaths[0].length; i++) {
+  for (let i = 0; i < splitPaths[0].length -1; i++) {
     const thisFolder = splitPaths[0][i]
     const isCommon = splitPaths.every(
       (singlePath) => singlePath[i] === thisFolder


### PR DESCRIPTION
…ory root

PR to prevent the following error:

Error: ENOTDIR: not a directory, chdir '...' -> 'i18n/index.ts/'

Glob used: \"i18n/*.{ts,tsx,js,jsx,json,yaml}\""

Example Structure:

```
├── i18n
│   ├── en
│   │   └── common.json
│   ├── es
│   │   └── common.json
│   ├── index.ts
